### PR TITLE
Added new method for EscapePod authentication & EscapePod examples

### DIFF
--- a/cmd/examples.escape-pod/battery/main.go
+++ b/cmd/examples.escape-pod/battery/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vector"
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vectorpb"
+)
+
+func main() {
+
+	v, err := vector.NewEP(
+		vector.WithTarget(os.Getenv("BOT_TARGET")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bs, err := v.Conn.BatteryState(
+		context.Background(),
+		&vectorpb.BatteryStateRequest{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(bs)
+
+}

--- a/cmd/examples.escape-pod/lift/main.go
+++ b/cmd/examples.escape-pod/lift/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vector"
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vectorpb"
+)
+
+func main() {
+
+	v, err := vector.NewEP(
+		vector.WithTarget(os.Getenv("BOT_TARGET")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	start := make(chan bool)
+	stop := make(chan bool)
+
+	go func() {
+		_ = v.BehaviorControl(ctx, start, stop)
+	}()
+
+	for {
+		select {
+		case <-start:
+			_, err := v.Conn.SetLiftHeight(
+				ctx,
+				&vectorpb.SetLiftHeightRequest{
+					HeightMm:          250,
+					MaxSpeedRadPerSec: 1,
+					IdTag:             2000001,
+					DurationSec:       .001,
+				},
+			)
+			if err != nil {
+				fmt.Println(err)
+			}
+			stop <- true
+			return
+		}
+	}
+
+}

--- a/cmd/examples.escape-pod/speak/main.go
+++ b/cmd/examples.escape-pod/speak/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vector"
+	"github.com/digital-dream-labs/vector-go-sdk/pkg/vectorpb"
+)
+
+func main() {
+
+	v, err := vector.NewEP(
+		vector.WithTarget(os.Getenv("BOT_TARGET")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	start := make(chan bool)
+	stop := make(chan bool)
+
+	go func() {
+		_ = v.BehaviorControl(ctx, start, stop)
+	}()
+
+	for {
+		select {
+		case <-start:
+			_, _ = v.Conn.SayText(
+				ctx,
+				&vectorpb.SayTextRequest{
+					Text:           "hello, hello, hello",
+					UseVectorVoice: true,
+					DurationScalar: 1.0,
+				},
+			)
+			stop <- true
+			return
+		}
+	}
+}

--- a/pkg/vector/vector.go
+++ b/pkg/vector/vector.go
@@ -1,6 +1,8 @@
 package vector
 
 import (
+	"context"
+	"flag"
 	"fmt"
 
 	"github.com/digital-dream-labs/hugh/grpc/client"
@@ -47,5 +49,52 @@ func New(opts ...Option) (*Vector, error) {
 	}
 
 	return &r, nil
+}
 
+// NewEP returns either a vector struct for escape pod vector, or an error on failure
+func NewEP(opts ...Option) (*Vector, error) {
+	cfg := options{}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.target == "" {
+		var host = flag.String("host", "", "Vector's IP address")
+		flag.Parse()
+		if *host == "" {
+			return nil, fmt.Errorf("please set the BOT_TARGET env variable, or use the -host argument and set it to your robots IP address")
+		}
+		cfg.target = fmt.Sprintf("%s:443", *host)
+	}
+	if cfg.target == "" {
+		return nil, fmt.Errorf("configuration options missing")
+	}
+
+	c, err := client.New(
+		client.WithTarget(cfg.target),
+		client.WithInsecureSkipVerify(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Connect(); err != nil {
+		return nil, err
+	}
+
+	vc := vectorpb.NewExternalInterfaceClient(c.Conn())
+
+	login, err := vc.UserAuthentication(context.Background(),
+		&vectorpb.UserAuthenticationRequest{
+			UserSessionId: []byte("anything1"),
+			ClientName:    []byte("anything2"),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(
+		WithTarget(cfg.target),
+		WithToken(string(login.ClientTokenGuid)),
+	)
 }


### PR DESCRIPTION
- added new 'NewEP' method for returning EscapePod Vector authenticated grpc client
- usage:
	v, err := vector.NewEP(
		vector.WithTarget(os.Getenv("BOT_TARGET")),
	)
- added new escape-pod examples into cmd/examples.escape-pod/* 

DEFECTS: This solution should be considered only as temporary, as each connection to EP robot will create its own token hash by calling UserAuthentication grpc, so the file at EP robot firmware /data/vic-gateway/token-hashes.json containing authenticated hashes will grow with each use of this SDK, until Token Hash file will consume all free space at robot's firmware and everything will crash. Received Token Hash should be rather stored locally for future re-usability.

EDIT: My mistake, there is no defect in the PR afterall, as because the constant "session token" in used for the authentication request, the previously generated token hash for that same "session" will get invalidated. So in fact, there should be always only one valid token hash for the given session - the currently received one. So in the end, it was correct, as nothing like token-hashes file overflow of newly generated tokens would ever happen...

However, for now, it seems that there is ONLY ONE valid token hash for the EP, no matter what "session id" is used in UserAuthentication request.? That, would on the other hand render the use of token hash stored on one device invalid, once the EP will be authenticated on another device...... This should be reviewed