### PR TITLE
feat: add options loading from .ini file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201207150747-9ee31aac76e7
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/ini.v1 v1.57.0
 )

--- a/go.sum
+++ b/go.sum
@@ -88,7 +88,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digital-dream-labs/hugh v0.0.0-20201230195335-18bf4b22cf9d/go.mod h1:aHzB67P53R70J1S9eI+Syr5HcCHIhS82y2M2jUqw5yA=
 github.com/digital-dream-labs/hugh v0.0.0-20210107135018-4ade8d79a71c h1:ZEaOauWyFIyq8eewKrpE0e6y0Re0YxsYs5tOuPmzorI=
 github.com/digital-dream-labs/hugh v0.0.0-20210107135018-4ade8d79a71c/go.mod h1:aHzB67P53R70J1S9eI+Syr5HcCHIhS82y2M2jUqw5yA=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -208,6 +207,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u+Tmr2evNHDiI=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.5/go.mod h1:fR9dOEfEyRM7ltVH0FTpK/QA6L/5BQq8izXNRu/gyVc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1 h1:X2vfSnm1WC8HEo0MBHZg2TcuDUHJj6kd1TmEAQncnSA=

--- a/pkg/vector/options.go
+++ b/pkg/vector/options.go
@@ -3,21 +3,26 @@ package vector
 // Option provides a function definition to set options
 type Option func(*options)
 
+// options holds the options for the vector robot.
 type options struct {
-	target string
-	token  string
+	Target string `ini:"ip"`
+	Token  string `ini:"guid"`
 }
 
 // WithTarget sets the ip of the vector robot.
 func WithTarget(s string) Option {
 	return func(o *options) {
-		o.target = s
+		if len(s) > 0 {
+			o.Target = s
+		}
 	}
 }
 
 // WithToken set the token for the vector robot.
 func WithToken(s string) Option {
 	return func(o *options) {
-		o.token = s
+		if len(s) > 0 {
+			o.Target = s
+		}
 	}
 }

--- a/pkg/vector/vector.go
+++ b/pkg/vector/vector.go
@@ -2,10 +2,13 @@ package vector
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/digital-dream-labs/hugh/grpc/client"
 	"github.com/digital-dream-labs/vector-go-sdk/pkg/vectorpb"
 	"google.golang.org/grpc"
+	"gopkg.in/ini.v1"
 )
 
 // Vector is the struct containing info about Vector
@@ -15,22 +18,31 @@ type Vector struct {
 
 // New returns either a vector struct, or an error on failure
 func New(opts ...Option) (*Vector, error) {
+
 	cfg := options{}
+
+	homedir, _ := os.UserHomeDir()
+	dirname := filepath.Join(homedir, ".anki_vector", "sdk_config.ini")
+
+	if initData, _ := ini.Load(dirname); initData != nil {
+		sec, _ := initData.GetSection(ini.DefaultSection)
+		sec.MapTo(&cfg)
+	}
 
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	if cfg.target == "" || cfg.token == "" {
+	if cfg.Target == "" || cfg.Token == "" {
 		return nil, fmt.Errorf("configuration options missing")
 	}
 
 	c, err := client.New(
-		client.WithTarget(cfg.target),
+		client.WithTarget(cfg.Target),
 		client.WithInsecureSkipVerify(),
 		client.WithDialopts(
 			grpc.WithPerRPCCredentials(
 				tokenAuth{
-					token: cfg.token,
+					token: cfg.Token,
 				},
 			),
 		),


### PR DESCRIPTION
## Description

Create a loader that reuses the existing format from the python SDK.
It's loading the options from the `~/.anki_vector/sdk_config.ini` path.

To ensure it will work well for Linux, macOS, and Windows, the loader uses `os.UserHomeDir()` to get the user home directory and `filepath.Join` to create a compatible file path.

### Linked Issues
_Write a configuration loader that reuses the existing format from the python sdk_ #1

### Notes

This code is not actually supporting 100% of the existing `.ini` format (for python SDK). It's only loading the information from the `DEFAULT` section, and mapping to a struct, like:

```ini
[DEFAULT]
cert = location_of_bot_cert.cert
ip = bot_ip_address
name = bot_name
guid = guid_aka_token
```

The code for getting the section is:
```go
sec, _ := initData.GetSection(ini.DefaultSection)
```
A suggestion to handle this is to add a "profile" that targets the wanted section, similar to AWS profiles in the CLI, and pass it as a parameter in `vector.New()` or something like this. So we could do something like:

> sdk_config.ini
```ini
[DEFAULT]
cert = location_of_bot_cert.cert
ip = bot_ip_address
name = bot_name
guid = guid_aka_token

[00507778]
cert = location_of_another_bot_cert.cert
ip = another_bot_ip_address
name = another_bot_name
guid = another_guid_aka_token
```

> section targeting in vector.go
```go
sec, _ := initData.GetSection(profile) // where profile is 00507778 (example)
```
And then it wil load the information about the *another bot*.

### Additionally

What do you think about add logging to the SDK? There are some **blank identifiers** ("_") for errors that should not crash the function, but it might be a good idea to display them.

Thoughts? @dietb @bussardrobbie 